### PR TITLE
Update readme to support .NET 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ This builds the buildpack's Go source using GOOS=linux by default. You can suppl
 
 To generate a sample app (like the ones that live in `integration/testdata`:
 
-```
+```bash
 app_name=my_sample_app
-runtime_version=3.1
+runtime_version=5.0
 
 rm -rf "integration/testdata/$app_name"
 mkdir "integration/testdata/$app_name"
 
-docker run -v "$PWD/integration/testdata/$app_name:/app" -it mcr.microsoft.com/dotnet/core/sdk:"$runtime_version" \
+docker run -v "$PWD/integration/testdata/$app_name:/app" -it mcr.microsoft.com/dotnet/sdk:"$runtime_version" \
   bash -c "
   mkdir /tmp/$app_name &&
     cd /tmp/$app_name &&


### PR DESCRIPTION
I've updated the readme content for generating a sample app to target .NET 5.0 instead of 3.1.  Because of that, I've also updated the repo of the image tag to use the new location (see https://github.com/dotnet/dotnet-docker/issues/2375).  Using the new location works with older .NET Core versions so there are no compatibility issues.