### PR TITLE
use scribe.Emitter for SelectedDependencies logging

### DIFF
--- a/log_emitter.go
+++ b/log_emitter.go
@@ -11,35 +11,20 @@ import (
 )
 
 type LogEmitter struct {
-	scribe.Logger
+	// Emitter is embedded and therefore delegates all of its functions to the
+	// LogEmitter.
+	scribe.Emitter
 }
 
 func NewLogEmitter(output io.Writer) LogEmitter {
 	return LogEmitter{
-		Logger: scribe.NewLogger(output),
+		Emitter: scribe.NewEmitter(output),
 	}
 }
 
 func (e LogEmitter) SelectedDependency(entry packit.BuildpackPlanEntry, dependency postal.Dependency, now time.Time) {
-	source, ok := entry.Metadata["version-source"].(string)
-	if !ok {
-		source = "<unknown>"
-	}
-
-	e.Subprocess("Selected %s version (using %s): %s", dependency.ID, source, dependency.Version)
-
-	if (dependency.DeprecationDate != time.Time{}) {
-		deprecationDate := dependency.DeprecationDate
-		switch {
-		case (deprecationDate.Add(-30*24*time.Hour).Before(now) && deprecationDate.After(now)):
-			e.Action("Version %s of %s will be deprecated after %s.", dependency.Version, dependency.ID, dependency.DeprecationDate.Format("2006-01-02"))
-			e.Action("Migrate your application to a supported version of %s before this time.", dependency.ID)
-		case (deprecationDate == now || deprecationDate.Before(now)):
-			e.Action("Version %s of %s is deprecated.", dependency.Version, dependency.ID)
-			e.Action("Migrate your application to a supported version of %s.", dependency.ID)
-		}
-	}
-	e.Break()
+	dependency.Name = dependency.ID
+	e.Emitter.SelectedDependency(entry, dependency, now)
 }
 
 func (e LogEmitter) Candidates(entries []packit.BuildpackPlanEntry) {

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -3,11 +3,9 @@ package dotnetcoreaspnet_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	dotnetcoreaspnet "github.com/paketo-buildpacks/dotnet-core-aspnet"
 	"github.com/paketo-buildpacks/packit"
-	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -24,101 +22,6 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		buffer = bytes.NewBuffer(nil)
 		emitter = dotnetcoreaspnet.NewLogEmitter(buffer)
-	})
-
-	context("SelectedDependency", func() {
-		it("prints details about the selected dependency", func() {
-			entry := packit.BuildpackPlanEntry{
-				Metadata: map[string]interface{}{
-					"version-source": "some-source",
-				},
-			}
-			dependency := postal.Dependency{
-				ID:      "dotnet-aspnetcore",
-				Version: "some-version",
-			}
-
-			emitter.SelectedDependency(entry, dependency, time.Now())
-			Expect(buffer.String()).To(Equal("    Selected dotnet-aspnetcore version (using some-source): some-version\n\n"))
-		})
-
-		context("when the version source is missing", func() {
-			it("prints details about the selected dependency", func() {
-				dependency := postal.Dependency{
-					ID:      "dotnet-aspnetcore",
-					Version: "some-version",
-				}
-
-				emitter.SelectedDependency(packit.BuildpackPlanEntry{}, dependency, time.Now())
-				Expect(buffer.String()).To(Equal("    Selected dotnet-aspnetcore version (using <unknown>): some-version\n\n"))
-			})
-		})
-
-		context("when it is within 30 days of the deprecation date", func() {
-			it("returns a warning that the dependency will be deprecated after the deprecation date", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate.Add(-29 * 24 * time.Hour)
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					ID:              "dotnet-aspnetcore",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected dotnet-aspnetcore version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of dotnet-aspnetcore will be deprecated after 2021-04-01.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of dotnet-aspnetcore before this time.\n\n"))
-			})
-		})
-
-		context("when it is on the the deprecation date", func() {
-			it("returns a warning that the version of the dependency is no longer supported", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					ID:              "dotnet-aspnetcore",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected dotnet-aspnetcore version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of dotnet-aspnetcore is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of dotnet-aspnetcore.\n\n"))
-			})
-		})
-
-		context("when it is after the the deprecation date", func() {
-			it("returns a warning that the version of the dependency is no longer supported", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-				now := deprecationDate.Add(24 * time.Hour)
-
-				entry := packit.BuildpackPlanEntry{
-					Metadata: map[string]interface{}{"version-source": "some-source"},
-				}
-				dependency := postal.Dependency{
-					DeprecationDate: deprecationDate,
-					ID:              "dotnet-aspnetcore",
-					Version:         "some-version",
-				}
-
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected dotnet-aspnetcore version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of dotnet-aspnetcore is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of dotnet-aspnetcore.\n\n"))
-			})
-		})
 	})
 
 	context("Candidates", func() {


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

Use scribe.emitter generic logger for EOS logging.
Note that in `log_emitter.go` we set `dependency.Name = depdendency.ID` since the dotnet core postal dependencies that get created from the buildpack.toml don't have the `Name` field.

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
