### PR TITLE
Changes root linker

### DIFF
--- a/dotnet_root_linker.go
+++ b/dotnet_root_linker.go
@@ -17,9 +17,17 @@ func (dl DotnetRootLinker) Link(workingDir, layerPath string) error {
 		return err
 	}
 
-	err = os.Symlink(filepath.Join(layerPath, "shared", "Microsoft.AspNetCore.App"), filepath.Join(workingDir, ".dotnet_root", "shared", "Microsoft.AspNetCore.App"))
+	files, err := filepath.Glob(filepath.Join(layerPath, "shared", "*"))
 	if err != nil {
 		return err
+	}
+
+	for _, f := range files {
+		filename := filepath.Base(f)
+		err := os.Symlink(filepath.Join(layerPath, "shared", filename), filepath.Join(workingDir, ".dotnet_root", "shared", filename))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- The root linker now symlinks all of the contents of shared into the
.dotnet_root dir instead of hardcoded files. This is to deal with layout
inconsistencies between 2.1.x and newer versions of .Net

Signed-off-by: Timothy Hitchener <thitchener@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
