### PR TITLE
Add project file as a version source in plan resolver

### DIFF
--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -53,6 +53,7 @@ func getPriority(source string) int {
 		priorities = map[string]int{
 			"RUNTIME_VERSION":        4,
 			"buildpack.yml":          3,
+			"runtimeconfig.json":     2,
 			`.*\.(cs)|(fs)|(vb)proj`: 2, // matches filename.(cs/fs/vb)proj
 			"":                       -1,
 		}

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -1,6 +1,7 @@
 package dotnetcoreaspnet
 
 import (
+	"regexp"
 	"sort"
 
 	"github.com/paketo-buildpacks/packit"
@@ -17,16 +18,6 @@ func NewPlanEntryResolver(logger LogEmitter) PlanEntryResolver {
 }
 
 func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.BuildpackPlanEntry {
-	var (
-		priorities = map[string]int{
-			"RUNTIME_VERSION": 4,
-			"buildpack.yml":   3,
-			"*sproj":          2,
-			"project file":    2,
-			"":                -1,
-		}
-	)
-
 	sort.Slice(entries, func(i, j int) bool {
 		leftSource := entries[i].Metadata["version-source"]
 		left, _ := leftSource.(string)
@@ -34,7 +25,7 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 		rightSource := entries[j].Metadata["version-source"]
 		right, _ := rightSource.(string)
 
-		return priorities[left] > priorities[right]
+		return getPriority(left) > getPriority(right)
 	})
 
 	chosenEntry := entries[0]
@@ -55,4 +46,26 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 	r.logger.Candidates(entries)
 
 	return chosenEntry
+}
+
+func getPriority(source string) int {
+	var (
+		priorities = map[string]int{
+			"RUNTIME_VERSION":        4,
+			"buildpack.yml":          3,
+			`.*\.(cs)|(fs)|(vb)proj`: 2, // matches filename.(cs/fs/vb)proj
+			"":                       -1,
+		}
+	)
+
+	if priority, ok := priorities[source]; ok {
+		return priority
+	}
+
+	for key, priority := range priorities {
+		if match, _ := regexp.MatchString(key, source); match {
+			return priority
+		}
+	}
+	return -1
 }

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -22,6 +22,7 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 			"RUNTIME_VERSION": 4,
 			"buildpack.yml":   3,
 			"*sproj":          2,
+			"project file":    2,
 			"":                -1,
 		}
 	)

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -55,45 +55,6 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when buildpack.yml and *sproj entries are included", func() {
-		it("resolves the best plan entry", func() {
-			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
-				{
-					Name: "dotnet-aspnetcore",
-					Metadata: map[string]interface{}{
-						"version": "other-version",
-					},
-				},
-				{
-					Name: "dotnet-aspnetcore",
-					Metadata: map[string]interface{}{
-						"version-source": "*sproj",
-						"version":        "*sproj-version",
-					},
-				},
-				{
-					Name: "dotnet-aspnetcore",
-					Metadata: map[string]interface{}{
-						"version-source": "buildpack.yml",
-						"version":        "buildpack-yml-version",
-					},
-				},
-			})
-			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name: "dotnet-aspnetcore",
-				Metadata: map[string]interface{}{
-					"version-source": "buildpack.yml",
-					"version":        "buildpack-yml-version",
-				},
-			}))
-
-			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      *sproj        -> \"*sproj-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
-		})
-	})
-
 	context("when buildpack.yml and project file entries are included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
@@ -106,7 +67,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-aspnetcore",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "my-app.fsproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -128,7 +89,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
 			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      project file  -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.fsproj -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
@@ -185,7 +146,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-aspnetcore",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "my-app.csproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -193,13 +154,13 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
 				Name: "dotnet-aspnetcore",
 				Metadata: map[string]interface{}{
-					"version-source": "project file",
+					"version-source": "my-app.csproj",
 					"version":        "project-file-version",
 				},
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      project file   -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.csproj  -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      unknown source -> \"other-version\""))
 		})
 	})

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -178,7 +178,8 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-aspnetcore",
 					Metadata: map[string]interface{}{
-						"version": "other-version",
+						"version":        "other-version",
+						"version-source": "unknown source",
 					},
 				},
 				{
@@ -198,8 +199,8 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      project file -> \"project-file-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>    -> \"other-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      project file   -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      unknown source -> \"other-version\""))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Frankie Gallina-Jones <frankieg@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Look for things that look like`filename.csproj` or `filename.fsproj` or `filename.vbproj` as a version source in plan resolver.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
