### PR TITLE
Fixes map indexing bug in entry resolver

### DIFF
--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -51,22 +51,16 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 func getPriority(source string) int {
 	var (
 		priorities = map[string]int{
-			"RUNTIME_VERSION":        4,
-			"buildpack.yml":          3,
-			"runtimeconfig.json":     2,
-			`.*\.(cs)|(fs)|(vb)proj`: 2, // matches filename.(cs/fs/vb)proj
-			"":                       -1,
+			"RUNTIME_VERSION":    4,
+			"buildpack.yml":      3,
+			"runtimeconfig.json": 2,
+			"":                   -1,
 		}
 	)
 
-	if priority, ok := priorities[source]; ok {
-		return priority
+	if match, _ := regexp.MatchString(`.*\.(cs)|(fs)|(vb)proj`, source); match {
+		return 2
 	}
 
-	for key, priority := range priorities {
-		if match, _ := regexp.MatchString(key, source); match {
-			return priority
-		}
-	}
-	return -1
+	return priorities[source]
 }


### PR DESCRIPTION
Signed-off-by: Tim Hitchener <thitchener@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes bug caused by nondeterminism in iterating through map keys in `getPriority()` function. Avoids iterating through map keys entirely.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
