### PR TITLE
The symlinker now runs during a rebuild

### DIFF
--- a/build.go
+++ b/build.go
@@ -75,6 +75,11 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery B
 			logger.Process("Reusing cached layer %s", aspNetLayer.Path)
 			logger.Break()
 
+			err = symlinker.Link(context.WorkingDir, aspNetLayer.Path)
+			if err != nil {
+				return packit.BuildResult{}, err
+			}
+
 			return packit.BuildResult{
 				Plan:   bom,
 				Layers: []packit.Layer{aspNetLayer},
@@ -89,7 +94,7 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery B
 
 		aspNetLayer.Launch = entry.Metadata["launch"] == true
 		aspNetLayer.Build = entry.Metadata["build"] == true
-		aspNetLayer.Cache = entry.Metadata["build"] == true
+		aspNetLayer.Cache = entry.Metadata["build"] == true || entry.Metadata["launch"] == true
 
 		logger.Subprocess("Installing Dotnet Core ASPNet %s", dependency.Version)
 		duration, err := clock.Measure(func() error {

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -95,11 +95,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(
-				And(
-					ContainSubstring("AspNetCore.dll exists"),
-				),
-			)
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
 		})
 	})
 }

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -16,7 +16,8 @@ import (
 
 func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 	var (
-		Expect = NewWithT(t).Expect
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
 
 		docker occam.Docker
 		pack   occam.Pack
@@ -55,10 +56,12 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 	context("an app is rebuilt and aspnet dependency is unchanged", func() {
 		it("reuses a layer from a previous build", func() {
 			var (
-				err         error
-				logs        fmt.Stringer
-				firstImage  occam.Image
-				secondImage occam.Image
+				err             error
+				logs            fmt.Stringer
+				firstImage      occam.Image
+				secondImage     occam.Image
+				firstContainer  occam.Container
+				secondContainer occam.Container
 			)
 
 			source, err = occam.Source(filepath.Join("testdata", "default_app"))
@@ -84,6 +87,24 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
 
+			firstContainer, err = docker.Container.Run.
+				WithCommand(
+					fmt.Sprintf(`test -f /layers/%s/dotnet-core-aspnet/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					test -f /workspace/.dotnet_root/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					echo 'AspNetCore.dll exists' &&
+					sleep infinity`,
+						strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))).
+				Execute(firstImage.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			containerIDs[firstContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
+
 			// Second pack build
 			secondImage, logs, err = build.Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
@@ -99,16 +120,36 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs.String()).To(ContainSubstring(fmt.Sprintf("  Reusing cached layer /layers/%s/dotnet-core-aspnet", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))))
 
 			Expect(secondImage.Buildpacks[1].Layers["dotnet-core-aspnet"].Metadata["built_at"]).To(Equal(firstImage.Buildpacks[1].Layers["dotnet-core-aspnet"].Metadata["built_at"]))
+
+			secondContainer, err = docker.Container.Run.
+				WithCommand(
+					fmt.Sprintf(`test -f /layers/%s/dotnet-core-aspnet/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					test -f /workspace/.dotnet_root/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					echo 'AspNetCore.dll exists' &&
+					sleep infinity`,
+						strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))).
+				Execute(secondImage.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			containerIDs[secondContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
 		})
 	})
 
 	context("an app is rebuilt and requirement changes", func() {
 		it("does not reuse a layer from the previous build", func() {
 			var (
-				err         error
-				logs        fmt.Stringer
-				firstImage  occam.Image
-				secondImage occam.Image
+				err             error
+				logs            fmt.Stringer
+				firstImage      occam.Image
+				secondImage     occam.Image
+				firstContainer  occam.Container
+				secondContainer occam.Container
 			)
 
 			source, err = occam.Source(filepath.Join("testdata", "default_app"))
@@ -140,6 +181,24 @@ dotnet-framework:
 
 			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
 
+			firstContainer, err = docker.Container.Run.
+				WithCommand(
+					fmt.Sprintf(`test -f /layers/%s/dotnet-core-aspnet/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					test -f /workspace/.dotnet_root/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					echo 'AspNetCore.dll exists' &&
+					sleep infinity`,
+						strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))).
+				Execute(firstImage.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			containerIDs[firstContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
+
 			// Second pack build
 			err = ioutil.WriteFile(filepath.Join(source, "buildpack.yml"), []byte(`---
 dotnet-framework:
@@ -161,6 +220,24 @@ dotnet-framework:
 			Expect(logs.String()).NotTo(ContainSubstring("Reusing cached layer"))
 
 			Expect(secondImage.Buildpacks[1].Layers["dotnet-core-aspnet"].Metadata["built_at"]).NotTo(Equal(firstImage.Buildpacks[1].Layers["dotnet-core-aspnet"].Metadata["built_at"]))
+
+			secondContainer, err = docker.Container.Run.
+				WithCommand(
+					fmt.Sprintf(`test -f /layers/%s/dotnet-core-aspnet/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					test -f /workspace/.dotnet_root/shared/Microsoft.AspNetCore.App/*/Microsoft.AspNetCore.dll &&
+					echo 'AspNetCore.dll exists' &&
+					sleep infinity`,
+						strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))).
+				Execute(secondImage.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			containerIDs[secondContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
 		})
 	})
 }

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -78,11 +78,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(
-				And(
-					ContainSubstring("AspNetCore.dll exists"),
-				),
-			)
+			}).Should(ContainSubstring("AspNetCore.dll exists"))
 		})
 	})
 }


### PR DESCRIPTION
- The aspnet layer is now always a cache layer because the layer needs
to be present on the file system for the symlinker to create the
necessary symlinks the the DOTNET_ROOT

Resolves #145

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
