### PR TITLE
Remove .NET 5

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -99,11 +99,6 @@ api = "0.6"
     patches = 2
 
   [[metadata.dependency-constraints]]
-    constraint = "5.0.*"
-    id = "dotnet-aspnetcore"
-    patches = 2
-
-  [[metadata.dependency-constraints]]
     constraint = "6.0.*"
     id = "dotnet-aspnetcore"
     patches = 2

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -42,32 +42,6 @@ api = "0.6"
     version = "3.1.24"
 
   [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:microsoft:asp.net_core:5.0:*:*:*:*:*:*:*"
-    deprecation_date = "2022-05-08T00:00:00Z"
-    id = "dotnet-aspnetcore"
-    licenses = ["MIT", "MIT-0"]
-    purl = "pkg:generic/dotnet-aspnetcore@5.0.15?checksum=c373b9c02c2be8e5813937e82d84d9093f4eb730b9c4ba4f9f12bc2e7c0aaea5&download_url=https://download.visualstudio.microsoft.com/download/pr/f1f37dfc-3f5b-49c3-be73-aa0839066e06/3dfbd1c2b1cf93f085db7ead99d76051/aspnetcore-runtime-5.0.15-linux-x64.tar.gz"
-    sha256 = "b29b34bfdc824776100a81aa68269be1bbb9ab5f289030a799cc397ced0156cf"
-    source = "https://download.visualstudio.microsoft.com/download/pr/f1f37dfc-3f5b-49c3-be73-aa0839066e06/3dfbd1c2b1cf93f085db7ead99d76051/aspnetcore-runtime-5.0.15-linux-x64.tar.gz"
-    source_sha256 = "c373b9c02c2be8e5813937e82d84d9093f4eb730b9c4ba4f9f12bc2e7c0aaea5"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/dotnet-aspnetcore/dotnet-aspnetcore_5.0.15_linux_x64_bionic_b29b34bf.tar.xz"
-    version = "5.0.15"
-
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:microsoft:asp.net_core:5.0:*:*:*:*:*:*:*"
-    deprecation_date = "2022-05-08T00:00:00Z"
-    id = "dotnet-aspnetcore"
-    licenses = ["MIT", "MIT-0"]
-    purl = "pkg:generic/dotnet-aspnetcore@5.0.16?checksum=ddf8385427c6b9e1ef5de2f58a0a1c0d496d405f9de445ffa7e5fef555c7fd34&download_url=https://download.visualstudio.microsoft.com/download/pr/fa584e5c-68f4-49e0-9a3d-79a52045b509/bc9bb7c98cfc975358b931cd5c2bf7a6/aspnetcore-runtime-5.0.16-linux-x64.tar.gz"
-    sha256 = "5f76620b4016d5f86e8fdfba466e98b905f84d89a23d969ac7f083bf468fecf7"
-    source = "https://download.visualstudio.microsoft.com/download/pr/fa584e5c-68f4-49e0-9a3d-79a52045b509/bc9bb7c98cfc975358b931cd5c2bf7a6/aspnetcore-runtime-5.0.16-linux-x64.tar.gz"
-    source_sha256 = "ddf8385427c6b9e1ef5de2f58a0a1c0d496d405f9de445ffa7e5fef555c7fd34"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/dotnet-aspnetcore/dotnet-aspnetcore_5.0.16_linux_x64_bionic_5f76620b.tar.xz"
-    version = "5.0.16"
-
-  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:microsoft:asp.net_core:6.0:*:*:*:*:*:*:*"
     deprecation_date = "2024-11-08T00:00:00Z"
     id = "dotnet-aspnetcore"

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -72,8 +72,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"      <unknown>       -> \"\"",
 				"",
 				MatchRegexp(`    Selected dotnet-aspnetcore version \(using RUNTIME_VERSION\): \d+\.\d+\.\d+`),
-				MatchRegexp(`      Version 5\.\d+\.\d+ of dotnet-aspnetcore will be deprecated after 2022-05-08.`),
-				"      Migrate your application to a supported version of dotnet-aspnetcore before this time.",
 				"",
 				"  Executing build process",
 				MatchRegexp(`    Installing Dotnet Core ASPNet \d+\.\d+\.\d+`),


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
.NET 5 goes out of support [on May 08 2022](https://github.com/dotnet/core/blob/a8f1599ee23485d5d5634eddaaa0c1b7bf89fc91/releases.md#net-releases).

Once it does, this change should be merged and released to remove .NET 5
support from the buildpack.

Related to https://github.com/paketo-buildpacks/dotnet-core-runtime/issues/281

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
