### PR TITLE
Use identical layer flag logic for all (re)builds

### DIFF
--- a/build.go
+++ b/build.go
@@ -115,7 +115,7 @@ func Build(
 				return packit.BuildResult{}, err
 			}
 
-			aspNetLayer.Launch, aspNetLayer.Build, aspNetLayer.Cache = launch, build, build
+			aspNetLayer.Launch, aspNetLayer.Build, aspNetLayer.Cache = launch, build, launch || build
 
 			return packit.BuildResult{
 				Layers: []packit.Layer{aspNetLayer},

--- a/build_test.go
+++ b/build_test.go
@@ -319,8 +319,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Name:   ".NET Core ASPNet",
 				SHA256: "some-sha",
 			}
-			entryResolver.MergeLayerTypesCall.Returns.Launch = false
-			entryResolver.MergeLayerTypesCall.Returns.Build = true
+			entryResolver.MergeLayerTypesCall.Returns.Launch = true
+			entryResolver.MergeLayerTypesCall.Returns.Build = false
 		})
 
 		it("exits build process early", func() {
@@ -356,14 +356,14 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				"dependency-sha": "some-sha",
 			}))
 
-			Expect(layer.Build).To(BeTrue())
-			Expect(layer.Launch).To(BeFalse())
+			Expect(layer.Build).To(BeFalse())
+			Expect(layer.Launch).To(BeTrue())
 			Expect(layer.Cache).To(BeTrue())
 
-			Expect(result.Build.BOM).To(HaveLen(1))
-			buildBOMEntry := result.Build.BOM[0]
-			Expect(buildBOMEntry.Name).To(Equal("dotnet-aspnetcore"))
-			Expect(buildBOMEntry.Metadata).To(Equal(paketosbom.BOMMetadata{
+			Expect(result.Launch.BOM).To(HaveLen(1))
+			launchBOMEntry := result.Launch.BOM[0]
+			Expect(launchBOMEntry.Name).To(Equal("dotnet-aspnetcore"))
+			Expect(launchBOMEntry.Metadata).To(Equal(paketosbom.BOMMetadata{
 				Version: "dotnet-aspnetcore-dep-version",
 				Checksum: paketosbom.BOMChecksum{
 					Algorithm: paketosbom.SHA256,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This fix addresses a user issue in which rebuilding an app suddenly results in a broken app image - `dotnet` cannot locate the ASP.NET Runtime in the app container. 

### Bug Reproduction Steps
1. Clone [this app](https://github.com/paketo-buildpacks/dotnet-core/blob/0ae419f5e4f866ddb947aba02250c68348fb3e39/integration/testdata/transitive-project-reference)
2. Use pack CLI to build with the latest version of the .NET Core buildpack
```
pack build repro-app  -b paketobuildpacks/dotnet-core:0.23.0 --env BP_DOTNET_PROJECT_PATH=src/WebApi
```
3. Rebuild the app with no changes
```
pack build repro-app  -b paketobuildpacks/dotnet-core:0.23.0 --env BP_DOTNET_PROJECT_PATH=src/WebApi
```
4. See that the app still runs as expected
```
docker run -it --rm repro-app
```
5. Rebuild the app (again)
```
pack build repro-app  -b paketobuildpacks/dotnet-core:0.23.0 --env BP_DOTNET_PROJECT_PATH=src/WebApi
```
6. See that the app fails to start because no frameworks can be found:
```
docker run -it --rm repro-app
Setting ASPNETCORE_URLS=http://0.0.0.0:8080
You must install or update .NET to run this application.

App: /workspace/WebApi
Architecture: x64
Framework: 'Microsoft.AspNetCore.App', version '6.0.0' (x64)
.NET location: /workspace/.dotnet_root

No frameworks were found.

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=6.0.0&arch=x64&rid=ubuntu.18.04-x64
```

### Root cause
The bug emerges from a couple of the buildpacks' behaviours interacting. The dotnet-execute buildpack [only requires ASP.NET at run-time](https://github.com/paketo-buildpacks/dotnet-execute/blob/7307c41d03aa0dd983229f1f1bd53f6c5c6f5f33/detect.go#L234), since it's not required for compiling .NET source code apps. The dotnet-core-aspnet buildpack has slightly different layer flag logic on fresh builds and cache-restoring builds.
On initial builds:
https://github.com/paketo-buildpacks/dotnet-core-aspnet/blob/5444a60de50ac65ff7f51f84ffb980129b4d4cb7/build.go#L133

On rebuilds:
https://github.com/paketo-buildpacks/dotnet-core-aspnet/blob/5444a60de50ac65ff7f51f84ffb980129b4d4cb7/build.go#L118

This means that on the **third** build, there is no cached ASP.NET layer to restore at build time. The symlinker iterates through the contents of an _empty_ ASP.NET layer and creates no useful symlinks.
https://github.com/paketo-buildpacks/dotnet-core-aspnet/blob/5444a60de50ac65ff7f51f84ffb980129b4d4cb7/dotnet_root_linker.go#L20
At run-time, the ASP.NET layer is present, but it's not symlinked into the `DOTNET_ROOT`.

This PR fixes the problem by ensuring that the ASP.NET layer will _remain_ cached when the buildpack restores the existing cached layer.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
